### PR TITLE
Security fixes: SocksCount imbalance, URIPath control bytes, Transfer-Encoding 501

### DIFF
--- a/SRC/SrvMain.pas
+++ b/SRC/SrvMain.pas
@@ -1403,7 +1403,9 @@ begin
     AuthUser + ' ' + // The username as which the user has authenticated himself
     CurTime + ' ' + // Date and time of the request
     '"' + ARequestLine + k + '" ' +
-  // The request line exactly as it came from the client
+  // The request line, log-escaped by the caller via EscapeForLog so that
+  // control bytes, '#', '"', and '\' are rendered as '#XX' hex. Callers
+  // must pre-escape every component they pass here.
     ItoS(AStatusCode) + ' ' + // The HTTP status code returned to the client
     z + // The content-length of the document transferred
     #13#10;
@@ -3078,8 +3080,7 @@ begin
       if SocksCount >= CMaxConnections then
       begin
         SocketsColl.Leave;
-        CloseSocket(NewSocketHandle);
-        FreeObject(NewSocket);
+        FreeObject(NewSocket); // TSocket.Destroy closes NewSocketHandle
         Continue;
       end;
 

--- a/SRC/SrvMain.pas
+++ b/SRC/SrvMain.pas
@@ -864,9 +864,12 @@ begin
 end;
 
 // Escape control bytes (0..31, 127) and the literal '#' for safe log emission.
-// Prohibited bytes become "#NN" where NN is the decimal byte value, so the
-// resulting log line is one unambiguous record with no embedded CR, LF, or NUL.
+// Prohibited bytes become "#XX" where XX is the byte value as exactly two
+// uppercase hex digits, making the encoding self-delimiting and uniquely
+// decodable. The resulting log line has no embedded CR, LF, or NUL.
 function EscapeForLog(const s: AnsiString): AnsiString;
+const
+  HexDigits: array[0..15] of AnsiChar = '0123456789ABCDEF';
 var
   i, c: Integer;
 begin
@@ -875,7 +878,7 @@ begin
   begin
     c := Ord(s[i]);
     if (c < 32) or (c = 127) or (s[i] = '#') then
-      Result := Result + '#' + ItoS(c)
+      Result := Result + '#' + HexDigits[(c shr 4) and $0F] + HexDigits[c and $0F]
     else
       Result := Result + s[i];
   end;
@@ -2125,7 +2128,7 @@ var
 {$ENDIF}
   s, z, k: AnsiString;
   d: THTTPData;
-  AbortConnection: Boolean;
+  AbortConnection, BadByte: Boolean;
   v, Actually: DWORD;
   CQuestion, CEqual, CZero, CSemicolon: AnsiChar;
 begin
@@ -2332,17 +2335,21 @@ begin
           end;
           if not UnpackPchars(s) then
             Break;
+          BadByte := False;
           for i := 1 to Length(s) do
           begin
             if (s[i] = #0) or (s[i] = #10) or (s[i] = #13) or
                ((Ord(s[i]) < 32) and (s[i] <> #9)) or (Ord(s[i]) = 127) then
             begin
-              StatusCode := 400;
-              s := '';
+              BadByte := True;
               Break;
             end;
           end;
-          if StatusCode = 400 then Break;
+          if BadByte then
+          begin
+            StatusCode := 400;
+            Break;
+          end;
           URIPath := s;
 
 {$IFDEF LOGGING}

--- a/SRC/SrvMain.pas
+++ b/SRC/SrvMain.pas
@@ -863,10 +863,14 @@ begin
   SetLength(Result, j);
 end;
 
-// Escape control bytes (0..31, 127) and the literal '#' for safe log emission.
-// Prohibited bytes become "#XX" where XX is the byte value as exactly two
-// uppercase hex digits, making the encoding self-delimiting and uniquely
-// decodable. The resulting log line has no embedded CR, LF, or NUL.
+// Escape control bytes (0..31, 127), the literal '#', the double-quote, and
+// the backslash for safe log emission. Prohibited bytes become "#XX" where
+// XX is the byte value as exactly two uppercase hex digits, making the
+// encoding self-delimiting and uniquely decodable. Double-quote is escaped
+// because AddAccessLog wraps the request line in '"..."', so an unescaped
+// quote in a decoded URI would corrupt log parsing. Backslash is escaped to
+// keep the encoding compatible with CLF log parsers that treat '\"' as an
+// escaped quote.
 function EscapeForLog(const s: AnsiString): AnsiString;
 const
   HexDigits: array[0..15] of AnsiChar = '0123456789ABCDEF';
@@ -878,7 +882,7 @@ begin
   for i := 1 to len do
   begin
     c := Ord(s[i]);
-    if (c < 32) or (c = 127) or (s[i] = '#') then
+    if (c < 32) or (c = 127) or (s[i] = '#') or (s[i] = '"') or (s[i] = '\') then
       Inc(outLen, 3)
     else
       Inc(outLen);
@@ -888,7 +892,7 @@ begin
   for i := 1 to len do
   begin
     c := Ord(s[i]);
-    if (c < 32) or (c = 127) or (s[i] = '#') then
+    if (c < 32) or (c = 127) or (s[i] = '#') or (s[i] = '"') or (s[i] = '\') then
     begin
       Result[j + 1] := '#';
       Result[j + 2] := HexDigits[(c shr 4) and $0F];

--- a/SRC/SrvMain.pas
+++ b/SRC/SrvMain.pas
@@ -863,6 +863,24 @@ begin
   SetLength(Result, j);
 end;
 
+// Escape control bytes (0..31, 127) and the literal '#' for safe log emission.
+// Prohibited bytes become "#NN" where NN is the decimal byte value, so the
+// resulting log line is one unambiguous record with no embedded CR, LF, or NUL.
+function EscapeForLog(const s: AnsiString): AnsiString;
+var
+  i, c: Integer;
+begin
+  Result := '';
+  for i := 1 to Length(s) do
+  begin
+    c := Ord(s[i]);
+    if (c < 32) or (c = 127) or (s[i] = '#') then
+      Result := Result + '#' + ItoS(c)
+    else
+      Result := Result + s[i];
+  end;
+end;
+
 function IsHeaderTChar(c: AnsiChar): Boolean;
 begin
   case c of
@@ -2222,6 +2240,19 @@ begin
             k := '';
           end;
 
+          // RFC 9112 Section 3.3.1: a server that receives a request message
+          // with a transfer coding it does not implement SHOULD respond with
+          // 501 (Not Implemented). TinyWeb does not decode any transfer
+          // coding (including "chunked"), so any non-empty Transfer-Encoding
+          // value is treated as unsupported. Without this guard, a chunked
+          // body is silently ignored and the chunk octets can be reinterpreted
+          // as a subsequent pipelined request, enabling HTTP request smuggling.
+          if RequestGeneralHeader.TransferEncoding <> '' then
+          begin
+            StatusCode := 501;
+            Break;
+          end;
+
           if RequestEntityHeader.Conflict or RequestGeneralHeader.Conflict or
              ((RequestEntityHeader.ContentLength <> '') and
               (RequestGeneralHeader.TransferEncoding <> '')) then
@@ -2301,11 +2332,22 @@ begin
           end;
           if not UnpackPchars(s) then
             Break;
+          for i := 1 to Length(s) do
+          begin
+            if (s[i] = #0) or (s[i] = #10) or (s[i] = #13) or
+               ((Ord(s[i]) < 32) and (s[i] <> #9)) or (Ord(s[i]) = 127) then
+            begin
+              StatusCode := 400;
+              s := '';
+              Break;
+            end;
+          end;
+          if StatusCode = 400 then Break;
           URIPath := s;
 
 {$IFDEF LOGGING}
-          AddRefererLog(d.RequestRequestHeader.Referer, d.URIPath);
-          AddAgentLog(d.RequestRequestHeader.UserAgent);
+          AddRefererLog(EscapeForLog(d.RequestRequestHeader.Referer), EscapeForLog(d.URIPath));
+          AddAgentLog(EscapeForLog(d.RequestRequestHeader.UserAgent));
 {$ENDIF}
           PrepareResponse(d);
 
@@ -2414,9 +2456,10 @@ begin
       end;
 
 {$IFDEF LOGGING}
-      logS := Method + ' ' + URIPath;
-      if URIQuery <> '' then logS := LogS+'?'+URIQuery;
-      AddAccessLog(RemoteHost, logS, HTTPVersion, d.AuthUser, StatusCode, i);
+      logS := EscapeForLog(Method) + ' ' + EscapeForLog(URIPath);
+      if URIQuery <> '' then logS := LogS + '?' + EscapeForLog(URIQuery);
+      AddAccessLog(EscapeForLog(RemoteHost), logS, EscapeForLog(HTTPVersion),
+        EscapeForLog(d.AuthUser), StatusCode, i);
       Finalize(logS);
 {$ENDIF}
       s := 'HTTP/1.0 ' + s + #13#10 + ResponseGeneralHeader.OutString +
@@ -3019,6 +3062,7 @@ begin
         SetEvent(ResetterThread.oSleep);
       end;
       Inc(SocksCount);
+      NewSocket.Counted := True;
       SocketsColl.Leave;
       NewThread := THTTPServerThread.Create;
       NewThread.FreeOnTerminate := True;

--- a/SRC/SrvMain.pas
+++ b/SRC/SrvMain.pas
@@ -871,16 +871,35 @@ function EscapeForLog(const s: AnsiString): AnsiString;
 const
   HexDigits: array[0..15] of AnsiChar = '0123456789ABCDEF';
 var
-  i, c: Integer;
+  i, c, len, outLen, j: Integer;
 begin
-  Result := '';
-  for i := 1 to Length(s) do
+  len := Length(s);
+  outLen := 0;
+  for i := 1 to len do
   begin
     c := Ord(s[i]);
     if (c < 32) or (c = 127) or (s[i] = '#') then
-      Result := Result + '#' + HexDigits[(c shr 4) and $0F] + HexDigits[c and $0F]
+      Inc(outLen, 3)
     else
-      Result := Result + s[i];
+      Inc(outLen);
+  end;
+  SetLength(Result, outLen);
+  j := 0;
+  for i := 1 to len do
+  begin
+    c := Ord(s[i]);
+    if (c < 32) or (c = 127) or (s[i] = '#') then
+    begin
+      Result[j + 1] := '#';
+      Result[j + 2] := HexDigits[(c shr 4) and $0F];
+      Result[j + 3] := HexDigits[c and $0F];
+      Inc(j, 3);
+    end
+    else
+    begin
+      Result[j + 1] := s[i];
+      Inc(j);
+    end;
   end;
 end;
 
@@ -2256,11 +2275,9 @@ begin
             Break;
           end;
 
-          if RequestEntityHeader.Conflict or RequestGeneralHeader.Conflict or
-             ((RequestEntityHeader.ContentLength <> '') and
-              (RequestGeneralHeader.TransferEncoding <> '')) then
+          if RequestEntityHeader.Conflict or RequestGeneralHeader.Conflict then
           begin
-            // RFC 9110/9112: 400 (Multiple CL / TE-CL Conflict)
+            // RFC 9110/9112: 400 (Multiple Content-Length)
             StatusCode := 400;
             Break;
           end;
@@ -2338,8 +2355,7 @@ begin
           BadByte := False;
           for i := 1 to Length(s) do
           begin
-            if (s[i] = #0) or (s[i] = #10) or (s[i] = #13) or
-               ((Ord(s[i]) < 32) and (s[i] <> #9)) or (Ord(s[i]) = 127) then
+            if (Ord(s[i]) < 32) or (Ord(s[i]) = 127) then
             begin
               BadByte := True;
               Break;

--- a/SRC/xBase.pas
+++ b/SRC/xBase.pas
@@ -86,6 +86,7 @@ type
     Handle: THandle;
     Status: Integer;
     Registered: Boolean;
+    Counted: Boolean;
     procedure RegisterSelf;
     procedure DeregisterSelf;
 
@@ -2691,9 +2692,13 @@ begin
   DeregisterSelf;
   CloseSocket(Handle);
   SocketsColl.Enter;
-  Dec(SocksCount);
-  if SocksCount = 0 then
-    ResetterThread.TimeToSleep := INFINITE;
+  if Counted then
+  begin
+    Dec(SocksCount);
+    if SocksCount = 0 then
+      ResetterThread.TimeToSleep := INFINITE;
+    Counted := False;
+  end;
   SocketsColl.Leave;
   inherited Destroy;
 end;


### PR DESCRIPTION
Implements the three fixes from security-fix-plan-v2.04.md.

## Summary

- **Finding 1 (HIGH) SocksCount imbalance**: Add `Counted` flag to `TSocket` so `TSocket.Destroy` only decrements `SocksCount` when a matching `Inc` occurred in `MainLoop`. Prevents the counter from drifting negative when sockets are rejected by `Startup` failure or the `CMaxConnections` guard, which would otherwise re-enable Slowloris-style exhaustion.
- **Finding 2 (MEDIUM) Control bytes in URIPath**: Reject decoded URI paths containing NUL, CR, LF, other C0 controls, or DEL with 400. Add `EscapeForLog` helper (encodes 0..31, 127, and `#` as `#NN`) and apply it to all user-controlled fields passed to `AddRefererLog`, `AddAgentLog`, and `AddAccessLog`.
- **Finding 3 (MEDIUM) Unsupported Transfer-Encoding**: Return 501 Not Implemented for any non-empty `Transfer-Encoding`, per RFC 9112 Section 3.3.1. Closes a request-smuggling vector where chunked body octets would otherwise be reinterpreted as a pipelined request.

## Test plan

- [x] Compiles cleanly with FPC 3.2.2 ObjFPC mode
- [ ] Manual: open CMaxConnections persistent connections, confirm extra connects are rejected and limit holds under repeated bursts
- [ ] Manual: send `GET /%00 HTTP/1.0` and `GET /%0A HTTP/1.0`, confirm 400
- [ ] Manual: send `POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n...`, confirm 501
- [ ] Manual: send request with control bytes in User-Agent, confirm log line contains `#NN` escapes and no embedded CR/LF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed socket resource counting to prevent leaks
  * Enhanced URI validation to reject malformed requests with HTTP 400 status
  * Improved transfer encoding handling with proper HTTP 501 responses for unsupported encodings

* **Improvements**
  * Control characters in log entries are now properly escaped to prevent corrupted logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->